### PR TITLE
Trapezoidal map trace

### DIFF
--- a/Trajectory_Hotspots/Test_Trajectory_Hotspots/test_trapezoidal_map.cpp
+++ b/Trajectory_Hotspots/Test_Trajectory_Hotspots/test_trapezoidal_map.cpp
@@ -4,6 +4,7 @@
 #include "../Trajectory_Hotspots/pch.h"
 #include "../Trajectory_Hotspots/vec2.h"
 #include "../Trajectory_Hotspots/segment.h"
+#include "../Trajectory_Hotspots/trajectory.h"
 #include "../Trajectory_Hotspots/trapezoidal_map.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -623,5 +624,80 @@ namespace TestTrajectoryHotspots
             Assert::AreEqual(query_result_right_of_5, query_result_right_4->bottom_right);
             Assert::AreEqual(query_result_right_of_7, query_result_right_5->top_right);
         }
+
+        TEST_METHOD(left_right_trace_in_trapezoid)
+        {
+
+            const std::vector<Vec2> trajectory_points
+            {
+                Vec2(4.f, 4.f),
+                Vec2(6.f, 8.f),
+                Vec2(8.f, 3.f),
+                Vec2(10.f, 6.f),
+                Vec2(12.f, 2.f),
+                Vec2(16.f, 9.f)
+            };
+
+            Trajectory trajectory(trajectory_points);
+
+            Trapezoidal_Map trapezoidal_map(trajectory.get_ordered_trajectory_segments());
+
+            Vec2 trace_point(9.f, 7.f);
+
+            const Segment* left_segment;
+            const Segment* right_segment;
+
+            trapezoidal_map.trace_left_right(trace_point, true, left_segment, right_segment);
+
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[1], *left_segment);
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[4], *right_segment);
+
+            left_segment = nullptr;
+            right_segment = nullptr;
+            
+            trace_point = Vec2(10.f, 4.f);
+
+            trapezoidal_map.trace_left_right(trace_point, true, left_segment, right_segment);
+
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[2], *left_segment);
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[3], *right_segment);
+
+            trapezoidal_map.trace_left_right(trace_point, false, left_segment, right_segment);
+
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[2], *left_segment);
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[3], *right_segment);
+        }
+
+        TEST_METHOD(left_right_trace_in_trapezoid_edge_case_on_point)
+        {
+
+            const std::vector<Vec2> trajectory_points
+            {
+                Vec2(4.f, 4.f),
+                Vec2(6.f, 8.f),
+                Vec2(8.f, 3.f),
+                Vec2(10.f, 6.f),
+                Vec2(12.f, 2.f),
+                Vec2(16.f, 9.f)
+            };
+
+            Trajectory trajectory(trajectory_points);
+
+            Trapezoidal_Map trapezoidal_map(trajectory.get_ordered_trajectory_segments());
+
+            Vec2 trace_point(10.f, 6.f);
+
+            const Segment* left_segment;
+            const Segment* right_segment;
+
+            trapezoidal_map.trace_left_right(trace_point, true, left_segment, right_segment);
+
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[1], *left_segment);
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[4], *right_segment);
+        }
+
+
+
+
     };
 }

--- a/Trajectory_Hotspots/Test_Trajectory_Hotspots/test_trapezoidal_map.cpp
+++ b/Trajectory_Hotspots/Test_Trajectory_Hotspots/test_trapezoidal_map.cpp
@@ -654,7 +654,7 @@ namespace TestTrajectoryHotspots
 
             left_segment = nullptr;
             right_segment = nullptr;
-            
+
             trace_point = Vec2(10.f, 4.f);
 
             trapezoidal_map.trace_left_right(trace_point, true, left_segment, right_segment);
@@ -668,7 +668,7 @@ namespace TestTrajectoryHotspots
             Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[3], *right_segment);
         }
 
-        TEST_METHOD(left_right_trace_in_trapezoid_edge_case_on_point)
+        TEST_METHOD(left_right_trace_in_trapezoid_edge_case_on_point_top_side)
         {
 
             const std::vector<Vec2> trajectory_points
@@ -685,7 +685,8 @@ namespace TestTrajectoryHotspots
 
             Trapezoidal_Map trapezoidal_map(trajectory.get_ordered_trajectory_segments());
 
-            Vec2 trace_point(10.f, 6.f);
+            //Both far
+            Vec2 trace_point = trajectory_points[3];
 
             const Segment* left_segment;
             const Segment* right_segment;
@@ -694,9 +695,80 @@ namespace TestTrajectoryHotspots
 
             Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[1], *left_segment);
             Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[4], *right_segment);
+
+            //To infinity
+            trace_point = trajectory_points[5];
+
+            left_segment = nullptr;
+            right_segment = nullptr;
+
+            trapezoidal_map.trace_left_right(trace_point, true, left_segment, right_segment);
+
+            Assert::IsTrue(&trapezoidal_map.left_border == left_segment);
+            Assert::IsTrue(&trapezoidal_map.right_border == right_segment);
+
+            //Both neighbouring segments
+            trace_point = trajectory_points[4];
+
+            left_segment = nullptr;
+            right_segment = nullptr;
+
+            trapezoidal_map.trace_left_right(trace_point, true, left_segment, right_segment);
+
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[3], *left_segment);
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[4], *right_segment);
         }
 
+        TEST_METHOD(left_right_trace_in_trapezoid_edge_case_on_point_bottom_side)
+        {
 
+            const std::vector<Vec2> trajectory_points
+            {
+                Vec2(4.f, 4.f),
+                Vec2(6.f, 8.f),
+                Vec2(8.f, 7.f),
+                Vec2(10.f, 5.f),
+                Vec2(12.f, 6.f),
+                Vec2(16.f, 2.f)
+            };
+
+            Trajectory trajectory(trajectory_points);
+
+            Trapezoidal_Map trapezoidal_map(trajectory.get_ordered_trajectory_segments());
+
+            //Right connected, left further
+            Vec2 trace_point = trajectory_points[2];
+
+            const Segment* left_segment;
+            const Segment* right_segment;
+
+            trapezoidal_map.trace_left_right(trace_point, false, left_segment, right_segment);
+
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[0], *left_segment);
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[2], *right_segment);
+
+            //Both to infinity
+            trace_point = trajectory_points[5];
+
+            left_segment = nullptr;
+            right_segment = nullptr;
+
+            trapezoidal_map.trace_left_right(trace_point, false, left_segment, right_segment);
+
+            Assert::IsTrue(&trapezoidal_map.left_border == left_segment);
+            Assert::IsTrue(&trapezoidal_map.right_border == right_segment);
+
+            //Both connected segments
+            trace_point = trajectory_points[4];
+
+            left_segment = nullptr;
+            right_segment = nullptr;
+
+            trapezoidal_map.trace_left_right(trace_point, false, left_segment, right_segment);
+
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[3], *left_segment);
+            Assert::AreEqual(trajectory.get_ordered_trajectory_segments()[4], *right_segment);
+        }
 
 
     };

--- a/Trajectory_Hotspots/Trajectory_Hotspots/segment.cpp
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/segment.cpp
@@ -41,6 +41,40 @@ const Vec2* Segment::get_top_point() const
 
 }
 
+const Vec2* Segment::get_left_point() const
+{
+    if (start.x < end.x)
+    {
+        return &start;
+    }
+    else
+    {
+        return &end;
+    }
+}
+
+const Vec2* Segment::get_right_point() const
+{
+    if (start.x < end.x)
+    {
+        return &end;
+    }
+    else
+    {
+        return &start;
+    }
+}
+
+bool Segment::is_horizontal() const
+{
+    return start.y == end.y;
+}
+
+bool Segment::is_vertical() const
+{
+    return start.x == end.x;
+}
+
 //Check if segments share a y-axis
 bool Segment::x_overlap(const Segment& other_segment) const
 {
@@ -232,17 +266,20 @@ Vec2 Segment::get_point_at_time(const Float time) const
     return (start + vector_to_point);
 }
 
+//Returns the orientation of a point vs the segment, <0 is left, >0 is right, 0 is on the segment
+Float Segment::point_direction(const Vec2& point) const
+{
+    const Vec2* top = get_top_point();
+    const Vec2* bottom = get_bottom_point();
+
+    return (point.x - bottom->x) * (top->y - bottom->y) - (point.y - bottom->y) * (top->x - bottom->x);
+}
+
 //Determine if a point lies to the left (false) or right (true) of a segment, oriented from start to end
 //If the point lies on the segment this function will return true (right)
 bool point_right_of_segment(const Segment& segment, const Vec2& point)
 {
-    //TODO: Force end always top so we can remove this check?
-    const Vec2* top = segment.get_top_point();
-    const Vec2* bottom = segment.get_bottom_point();
-
-    Float direction = (point.x - bottom->x) * (top->y - bottom->y) - (point.y - bottom->y) * (top->x - bottom->x);
-
-    return direction < 0 ? false : true;
+    return segment.point_direction(point) < 0 ? false : true;
 }
 
 bool Segment::operator==(const Segment& operand) const

--- a/Trajectory_Hotspots/Trajectory_Hotspots/segment.h
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/segment.h
@@ -59,6 +59,14 @@ public:
 
     const Vec2* get_bottom_point() const;
     const Vec2* get_top_point() const;
+    const Vec2* get_left_point() const;
+    const Vec2* get_right_point() const;
+
+    //Returns the orientation of a point vs the segment, <0 is left, >0 is right, 0 is on the segment
+    Float point_direction(const Vec2& point) const;
+
+    bool is_horizontal() const;
+    bool is_vertical() const;
 
     //Determines if two segments share a y-axis
     bool x_overlap(const Segment& segment) const;

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trajectory.cpp
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trajectory.cpp
@@ -30,6 +30,11 @@ Trajectory::Trajectory(const std::vector<Vec2>& ordered_trajectory_points)
     trajectory_length = start_t;
 }
 
+const std::vector<Segment>& Trajectory::get_ordered_trajectory_segments() const
+{
+    return trajectory_segments;
+}
+
 //Returns a hotspot with a fixed radius at a position that maximizes the trajectory inside it
 AABB Trajectory::get_hotspot_fixed_radius(Float radius) const
 {

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trajectory.h
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trajectory.h
@@ -16,6 +16,8 @@ public:
     AABB get_hotspot_fixed_radius_contiguous(Float radius) const;
     AABB get_hotspot_fixed_length_contiguous(Float length) const;
 
+    const std::vector<Segment>& get_ordered_trajectory_segments() const;
+
 private:
 
     Float trajectory_start = 0.f;

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.cpp
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.cpp
@@ -811,6 +811,7 @@ void Trapezoidal_Map::add_overlapping_segment(const std::vector<Trapezoidal_Leaf
     }
 }
 
+
 //Follow along the segment from bottom to top registering the trapezoids it intersects
 //Returns the intersected trapezoids ordered from bottom to top
 std::vector<Trapezoidal_Leaf_Node*> Trapezoidal_Map::follow_segment(const Segment& query_segment)
@@ -994,7 +995,6 @@ Trapezoidal_Leaf_Node* Trapezoidal_X_Node::query_start_point(const Segment& quer
 
     //If the startpoint of the query segment is the same as the endpoint of this segment, the query segment lies to the right.
     //(This is always true because we order the start and endpoints from left to right and only use this for a graph, so all points have degree 2)
-    //TODO: Test if this needs to be nearly_equal, we init with the same points...
     if (query_segment.start == segment->end)
     {
         return right->query_start_point(query_segment);
@@ -1024,6 +1024,81 @@ Trapezoidal_Leaf_Node* Trapezoidal_Y_Node::query_start_point(const Segment& quer
     {
         return below->query_start_point(query_segment);
     }
+}
+
+void Trapezoidal_Map::trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const
+{
+    root->trace_left_right(point, left_segment, right_segment);
+}
+
+void Trapezoidal_X_Node::trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const
+{
+    //TODO: On segment, never happens in our use case?
+    if (point_right_of_segment(*segment, point))
+    {
+        //Right of, or on segment
+        right->trace_left_right(point, left_segment, right_segment);
+    }
+    else
+    {
+        left->trace_left_right(point, left_segment, right_segment);
+    }
+}
+
+void Trapezoidal_Y_Node::trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const
+{
+    //TODO: Point on point
+
+    if (point == *this->point)
+    {
+
+    }
+
+    if (point.y >= this->point->y)
+    {
+        //Above or on point
+        above->trace_left_right(point, left_segment, right_segment);
+    }
+    else
+    {
+        below->trace_left_right(point, left_segment, right_segment);
+    }
+}
+
+void Trapezoidal_Leaf_Node::trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const
+{
+    left_segment = this->left_segment;
+    left_segment = this->right_segment;
+}
+
+void Trapezoidal_X_Node::trace_left(const Vec2& point, const Segment*& left_segment) const
+{
+
+}
+
+void Trapezoidal_Y_Node::trace_left(const Vec2& point, const Segment*& left_segment) const
+{
+
+}
+
+void Trapezoidal_Leaf_Node::trace_left(const Vec2& point, const Segment*& left_segment) const
+{
+
+}
+
+void Trapezoidal_X_Node::trace_right(const Vec2& point, const Segment*& right_segment) const
+{
+
+}
+
+void Trapezoidal_Y_Node::trace_right(const Vec2& point, const Segment*& right_segment) const
+{
+
+}
+
+void Trapezoidal_Leaf_Node::trace_right(const Vec2& point, const Segment*& right_segment) const
+{
+
 }
 
 void Trapezoidal_X_Node::replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child)

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.cpp
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.cpp
@@ -14,7 +14,7 @@ Trapezoidal_Map::Trapezoidal_Map()
     root = std::make_unique<Trapezoidal_Leaf_Node>(&left_border, &right_border, &bottom_point, &top_point);
 }
 
-Trapezoidal_Map::Trapezoidal_Map(std::vector<Segment>& trajectory_segments, const unsigned int seed)
+Trapezoidal_Map::Trapezoidal_Map(const std::vector<Segment>& trajectory_segments, const unsigned int seed)
 {
     AABB bounding_box(-std::numeric_limits<float>::infinity(), -std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity());
 
@@ -1132,7 +1132,7 @@ void Trapezoidal_X_Node::trace_left(const Vec2& point, const bool prefer_top, co
         {
             //TODO: Check for endpoint?
             //Segment leaves the bounds, return
-            left_segment == this->segment;
+            left_segment = this->segment;
         }
         else
         {
@@ -1151,7 +1151,7 @@ void Trapezoidal_Y_Node::trace_left(const Vec2& point, const bool prefer_top, co
         //If horizontal shoot over/under (based on prefered)
         if (upwards_segment == prefer_top && !this->left_segment->is_horizontal())
         {
-            left_segment == this->left_segment;
+            left_segment = this->left_segment;
         }
         else
         {
@@ -1200,7 +1200,7 @@ void Trapezoidal_X_Node::trace_right(const Vec2& point, const bool prefer_top, c
         {
             //TODO: Check for endpoint?
             //Segment leaves the bounds, return
-            right_segment == this->segment;
+            right_segment = this->segment;
         }
         else
         {
@@ -1219,7 +1219,7 @@ void Trapezoidal_Y_Node::trace_right(const Vec2& point, const bool prefer_top, c
         //If horizontal shoot over/under (based on prefered)
         if (upwards_segment == prefer_top && !this->right_segment->is_horizontal())
         {
-            right_segment == this->right_segment;
+            right_segment = this->right_segment;
         }
         else
         {

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
@@ -13,7 +13,7 @@ public:
     virtual Trapezoidal_Leaf_Node* query_point(const Vec2& point) = 0;
     virtual Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment) = 0;
 
-    virtual void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const = 0;
+    virtual void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const = 0;
 
     //TODO: Friend class?
     std::vector<Trapezoidal_Internal_Node*> parents;
@@ -24,8 +24,8 @@ public:
     friend class Trapezoidal_Y_Node;
 
 private:
-    virtual void trace_left(const Vec2& point, const Segment*& left_segment) const = 0;
-    virtual void trace_right(const Vec2& point, const Segment*& right_segment) const = 0;
+    virtual void trace_left(const Vec2& point, const Segment*& left_segment, const bool prefer_top) const = 0;
+    virtual void trace_right(const Vec2& point, const Segment*& right_segment, const bool prefer_top) const = 0;
 };
 
 class Trapezoidal_Internal_Node : public Trapezoidal_Node
@@ -54,11 +54,11 @@ public:
     void replace_bottom_neighbour(Trapezoidal_Leaf_Node* old_bottom_neighbour, Trapezoidal_Leaf_Node* new_bottom_neighbour);
     void replace_top_neighbour(Trapezoidal_Leaf_Node* old_top_neighbour, Trapezoidal_Leaf_Node* new_top_neighbour);
 
-    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const;
+    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const;
 
 private:
-    void trace_left(const Vec2& point, const Segment*& left_segment) const;
-    void trace_right(const Vec2& point, const Segment*& right_segment) const;
+    void trace_left(const Vec2& point, const Segment*& left_segment, const bool prefer_top) const;
+    void trace_right(const Vec2& point, const Segment*& right_segment, const bool prefer_top) const;
 
 public:
 
@@ -94,11 +94,11 @@ public:
     Trapezoidal_Leaf_Node* query_point(const Vec2& point);
     Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment);
 
-    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const;
+    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const;
 
 private:
-    void trace_left(const Vec2& point, const Segment*& left_segment) const;
-    void trace_right(const Vec2& point, const Segment*& right_segment) const;
+    void trace_left(const Vec2& point, const Segment*& left_segment, const bool prefer_top) const;
+    void trace_right(const Vec2& point, const Segment*& right_segment, const bool prefer_top) const;
 
 public:
     void replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child);
@@ -115,17 +115,17 @@ class Trapezoidal_Y_Node : public Trapezoidal_Internal_Node
 {
 public:
 
-    Trapezoidal_Y_Node() : Trapezoidal_Internal_Node(), point(nullptr), below(nullptr), above(nullptr)
+    Trapezoidal_Y_Node() : Trapezoidal_Internal_Node(), point(nullptr), left_segment(nullptr), right_segment(nullptr), below(nullptr), above(nullptr)
     {
 
     }
 
-    Trapezoidal_Y_Node(const Vec2* point) : Trapezoidal_Internal_Node(), point(point), below(nullptr), above(nullptr)
+    Trapezoidal_Y_Node(const Vec2* point) : Trapezoidal_Internal_Node(), point(point), left_segment(nullptr), right_segment(nullptr), below(nullptr), above(nullptr)
     {
 
     }
 
-    Trapezoidal_Y_Node(const Vec2* point, std::shared_ptr<Trapezoidal_Node> below, std::shared_ptr<Trapezoidal_Node> above) : Trapezoidal_Internal_Node(), point(point), below(below), above(above)
+    Trapezoidal_Y_Node(const Vec2* point, std::shared_ptr<Trapezoidal_Node> below, std::shared_ptr<Trapezoidal_Node> above) : Trapezoidal_Internal_Node(), point(point), left_segment(nullptr), right_segment(nullptr), below(below), above(above)
     {
         below->parents.push_back(this);
         above->parents.push_back(this);
@@ -134,16 +134,20 @@ public:
     Trapezoidal_Leaf_Node* query_point(const Vec2& point);
     Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment);
 
-    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const;
+    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const;
+
+    void attach_segment(const Segment* segment);
 
 private:
-    void trace_left(const Vec2& point, const Segment*& left_segment) const;
-    void trace_right(const Vec2& point, const Segment*& right_segment) const;
+    void trace_left(const Vec2& point, const Segment*& left_segment, const bool prefer_top) const;
+    void trace_right(const Vec2& point, const Segment*& right_segment, const bool prefer_top) const;
 
 public:
     void replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child);
 
     const Vec2* point;
+    const Segment* left_segment;
+    const Segment* right_segment;
 
     std::shared_ptr<Trapezoidal_Node> below;
     std::shared_ptr<Trapezoidal_Node> above;
@@ -165,7 +169,7 @@ public:
     void add_fully_embedded_segment_with_bottom_endpoint_overlapping(Trapezoidal_Leaf_Node* current_trapezoid, const Segment& segment);
     void add_overlapping_segment(const std::vector<Trapezoidal_Leaf_Node*>& overlapping_trapezoids, const Segment& segment);
 
-    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const;
+    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const;
     //void trace_left(const Vec2& point, const Segment& left_segment) const;
     //void trace_right(const Vec2& point, const Segment& right_segment) const;
 

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
@@ -9,10 +9,23 @@ public:
 
     Trapezoidal_Node() = default;
 
+    //TODO: Shouldn't this be const?
     virtual Trapezoidal_Leaf_Node* query_point(const Vec2& point) = 0;
     virtual Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment) = 0;
 
+    virtual void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const = 0;
+
+    //TODO: Friend class?
     std::vector<Trapezoidal_Internal_Node*> parents;
+
+    friend class Trapezoidal_Node;
+    friend class Trapezoidal_Leaf_Node;
+    friend class Trapezoidal_X_Node;
+    friend class Trapezoidal_Y_Node;
+
+private:
+    virtual void trace_left(const Vec2& point, const Segment*& left_segment) const = 0;
+    virtual void trace_right(const Vec2& point, const Segment*& right_segment) const = 0;
 };
 
 class Trapezoidal_Internal_Node : public Trapezoidal_Node
@@ -41,9 +54,15 @@ public:
     void replace_bottom_neighbour(Trapezoidal_Leaf_Node* old_bottom_neighbour, Trapezoidal_Leaf_Node* new_bottom_neighbour);
     void replace_top_neighbour(Trapezoidal_Leaf_Node* old_top_neighbour, Trapezoidal_Leaf_Node* new_top_neighbour);
 
+    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const;
+
+private:
+    void trace_left(const Vec2& point, const Segment*& left_segment) const;
+    void trace_right(const Vec2& point, const Segment*& right_segment) const;
+
 public:
 
-	
+
     Trapezoidal_Leaf_Node* bottom_left;
     Trapezoidal_Leaf_Node* bottom_right;
     Trapezoidal_Leaf_Node* top_left;
@@ -75,6 +94,13 @@ public:
     Trapezoidal_Leaf_Node* query_point(const Vec2& point);
     Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment);
 
+    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const;
+
+private:
+    void trace_left(const Vec2& point, const Segment*& left_segment) const;
+    void trace_right(const Vec2& point, const Segment*& right_segment) const;
+
+public:
     void replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child);
 
     const Segment* segment;
@@ -108,6 +134,13 @@ public:
     Trapezoidal_Leaf_Node* query_point(const Vec2& point);
     Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment);
 
+    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const;
+
+private:
+    void trace_left(const Vec2& point, const Segment*& left_segment) const;
+    void trace_right(const Vec2& point, const Segment*& right_segment) const;
+
+public:
     void replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child);
 
     const Vec2* point;
@@ -131,6 +164,10 @@ public:
     void add_fully_embedded_segment_with_top_endpoint_overlapping(Trapezoidal_Leaf_Node* current_trapezoid, const Segment& segment);
     void add_fully_embedded_segment_with_bottom_endpoint_overlapping(Trapezoidal_Leaf_Node* current_trapezoid, const Segment& segment);
     void add_overlapping_segment(const std::vector<Trapezoidal_Leaf_Node*>& overlapping_trapezoids, const Segment& segment);
+
+    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment) const;
+    //void trace_left(const Vec2& point, const Segment& left_segment) const;
+    //void trace_right(const Vec2& point, const Segment& right_segment) const;
 
 private:
 

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
@@ -159,7 +159,7 @@ class Trapezoidal_Map
 public:
     Trapezoidal_Map();
 
-    Trapezoidal_Map(std::vector<Segment>& trajectory_segments, const unsigned int seed = 0);
+    Trapezoidal_Map(const std::vector<Segment>& trajectory_segments, const unsigned int seed = 0);
 
     Trapezoidal_Leaf_Node* query_point(const Vec2& point);
 

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
@@ -15,7 +15,6 @@ public:
 
     virtual void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const = 0;
 
-    //TODO: Friend class?
     std::vector<Trapezoidal_Internal_Node*> parents;
 
     friend class Trapezoidal_Node;
@@ -24,8 +23,6 @@ public:
     friend class Trapezoidal_Y_Node;
 
 private:
-    virtual void trace_left(const Vec2& point, const bool prefer_top, const Segment*& left_segment) const = 0;
-    virtual void trace_right(const Vec2& point, const bool prefer_top, const Segment*& right_segment) const = 0;
 };
 
 class Trapezoidal_Internal_Node : public Trapezoidal_Node
@@ -56,13 +53,6 @@ public:
 
     void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const;
 
-private:
-    void trace_left(const Vec2& point, const bool prefer_top, const Segment*& left_segment) const;
-    void trace_right(const Vec2& point, const bool prefer_top, const Segment*& right_segment) const;
-
-public:
-
-
     Trapezoidal_Leaf_Node* bottom_left;
     Trapezoidal_Leaf_Node* bottom_right;
     Trapezoidal_Leaf_Node* top_left;
@@ -73,6 +63,8 @@ public:
 
     const Vec2* top_point;
     const Vec2* bottom_point;
+
+private:
 };
 
 //Trapezoidal X nodes represent segments of the trapezoidal map
@@ -96,17 +88,15 @@ public:
 
     void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const;
 
-private:
-    void trace_left(const Vec2& point, const bool prefer_top, const Segment*& left_segment) const;
-    void trace_right(const Vec2& point, const bool prefer_top, const Segment*& right_segment) const;
-
-public:
     void replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child);
 
     const Segment* segment;
 
     std::shared_ptr<Trapezoidal_Node> left;
     std::shared_ptr<Trapezoidal_Node> right;
+
+private:
+
 };
 
 //Trapezoidal Y nodes represent points of the trapezoidal map
@@ -115,17 +105,17 @@ class Trapezoidal_Y_Node : public Trapezoidal_Internal_Node
 {
 public:
 
-    Trapezoidal_Y_Node() : Trapezoidal_Internal_Node(), point(nullptr), left_segment(nullptr), right_segment(nullptr), below(nullptr), above(nullptr)
+    Trapezoidal_Y_Node() : Trapezoidal_Internal_Node(), point(nullptr), below(nullptr), above(nullptr)
     {
 
     }
 
-    Trapezoidal_Y_Node(const Vec2* point) : Trapezoidal_Internal_Node(), point(point), left_segment(nullptr), right_segment(nullptr), below(nullptr), above(nullptr)
+    Trapezoidal_Y_Node(const Vec2* point) : Trapezoidal_Internal_Node(), point(point), below(nullptr), above(nullptr)
     {
 
     }
 
-    Trapezoidal_Y_Node(const Vec2* point, std::shared_ptr<Trapezoidal_Node> below, std::shared_ptr<Trapezoidal_Node> above) : Trapezoidal_Internal_Node(), point(point), left_segment(nullptr), right_segment(nullptr), below(below), above(above)
+    Trapezoidal_Y_Node(const Vec2* point, std::shared_ptr<Trapezoidal_Node> below, std::shared_ptr<Trapezoidal_Node> above) : Trapezoidal_Internal_Node(), point(point), below(below), above(above)
     {
         below->parents.push_back(this);
         above->parents.push_back(this);
@@ -136,22 +126,14 @@ public:
 
     void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const;
 
-
-    void attach_segment(const Segment* segment);
-
-private:
-    void trace_left(const Vec2& point, const bool prefer_top, const Segment*& left_segment) const;
-    void trace_right(const Vec2& point, const bool prefer_top, const Segment*& right_segment) const;
-
-public:
     void replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child);
 
     const Vec2* point;
-    const Segment* left_segment;
-    const Segment* right_segment;
 
     std::shared_ptr<Trapezoidal_Node> below;
     std::shared_ptr<Trapezoidal_Node> above;
+
+private:
 };
 
 class Trapezoidal_Map
@@ -171,8 +153,6 @@ public:
     void add_overlapping_segment(const std::vector<Trapezoidal_Leaf_Node*>& overlapping_trapezoids, const Segment& segment);
 
     void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const;
-    //void trace_left(const Vec2& point, const Segment& left_segment) const;
-    //void trace_right(const Vec2& point, const Segment& right_segment) const;
 
 private:
 

--- a/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/trapezoidal_map.h
@@ -13,7 +13,7 @@ public:
     virtual Trapezoidal_Leaf_Node* query_point(const Vec2& point) = 0;
     virtual Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment) = 0;
 
-    virtual void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const = 0;
+    virtual void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const = 0;
 
     //TODO: Friend class?
     std::vector<Trapezoidal_Internal_Node*> parents;
@@ -24,8 +24,8 @@ public:
     friend class Trapezoidal_Y_Node;
 
 private:
-    virtual void trace_left(const Vec2& point, const Segment*& left_segment, const bool prefer_top) const = 0;
-    virtual void trace_right(const Vec2& point, const Segment*& right_segment, const bool prefer_top) const = 0;
+    virtual void trace_left(const Vec2& point, const bool prefer_top, const Segment*& left_segment) const = 0;
+    virtual void trace_right(const Vec2& point, const bool prefer_top, const Segment*& right_segment) const = 0;
 };
 
 class Trapezoidal_Internal_Node : public Trapezoidal_Node
@@ -54,11 +54,11 @@ public:
     void replace_bottom_neighbour(Trapezoidal_Leaf_Node* old_bottom_neighbour, Trapezoidal_Leaf_Node* new_bottom_neighbour);
     void replace_top_neighbour(Trapezoidal_Leaf_Node* old_top_neighbour, Trapezoidal_Leaf_Node* new_top_neighbour);
 
-    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const;
+    void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const;
 
 private:
-    void trace_left(const Vec2& point, const Segment*& left_segment, const bool prefer_top) const;
-    void trace_right(const Vec2& point, const Segment*& right_segment, const bool prefer_top) const;
+    void trace_left(const Vec2& point, const bool prefer_top, const Segment*& left_segment) const;
+    void trace_right(const Vec2& point, const bool prefer_top, const Segment*& right_segment) const;
 
 public:
 
@@ -94,11 +94,11 @@ public:
     Trapezoidal_Leaf_Node* query_point(const Vec2& point);
     Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment);
 
-    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const;
+    void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const;
 
 private:
-    void trace_left(const Vec2& point, const Segment*& left_segment, const bool prefer_top) const;
-    void trace_right(const Vec2& point, const Segment*& right_segment, const bool prefer_top) const;
+    void trace_left(const Vec2& point, const bool prefer_top, const Segment*& left_segment) const;
+    void trace_right(const Vec2& point, const bool prefer_top, const Segment*& right_segment) const;
 
 public:
     void replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child);
@@ -134,13 +134,14 @@ public:
     Trapezoidal_Leaf_Node* query_point(const Vec2& point);
     Trapezoidal_Leaf_Node* query_start_point(const Segment& query_segment);
 
-    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const;
+    void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const;
+
 
     void attach_segment(const Segment* segment);
 
 private:
-    void trace_left(const Vec2& point, const Segment*& left_segment, const bool prefer_top) const;
-    void trace_right(const Vec2& point, const Segment*& right_segment, const bool prefer_top) const;
+    void trace_left(const Vec2& point, const bool prefer_top, const Segment*& left_segment) const;
+    void trace_right(const Vec2& point, const bool prefer_top, const Segment*& right_segment) const;
 
 public:
     void replace_child(Trapezoidal_Node* old_child, std::shared_ptr<Trapezoidal_Node> new_child);
@@ -169,7 +170,7 @@ public:
     void add_fully_embedded_segment_with_bottom_endpoint_overlapping(Trapezoidal_Leaf_Node* current_trapezoid, const Segment& segment);
     void add_overlapping_segment(const std::vector<Trapezoidal_Leaf_Node*>& overlapping_trapezoids, const Segment& segment);
 
-    void trace_left_right(const Vec2& point, const Segment*& left_segment, const Segment*& right_segment, const bool prefer_top) const;
+    void trace_left_right(const Vec2& point, const bool prefer_top, const Segment*& left_segment, const Segment*& right_segment) const;
     //void trace_left(const Vec2& point, const Segment& left_segment) const;
     //void trace_right(const Vec2& point, const Segment& right_segment) const;
 

--- a/Trajectory_Hotspots/Trajectory_Hotspots/vec2.cpp
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/vec2.cpp
@@ -6,6 +6,11 @@ Float Vec2::dot(const Vec2& other) const
     return x * other.x + y * other.y;
 }
 
+Float Vec2::cross(const Vec2& other) const
+{
+    return (x * other.y) - (y * other.x);
+}
+
 Float Vec2::squared_length() const
 {
     return x * x + y * y;

--- a/Trajectory_Hotspots/Trajectory_Hotspots/vec2.h
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/vec2.h
@@ -13,6 +13,8 @@ public:
 
     Float dot(const Vec2& other) const;
 
+    Float cross(const Vec2& other) const;
+
     Float squared_length() const;
 
     Float length() const;


### PR DESCRIPTION
Added a trace_left_right function to the trapezoidal map that retrieves the left and right segments that are hit by a horizontal ray trace from the queried point.
It handles query points that lie on a vector (y node) correctly.