### PR TITLE
fix "incremental ltcg not compatible with address sanitizer"

### DIFF
--- a/Trajectory_Hotspots/Test_Trajectory_Hotspots/Test_Trajectory_Hotspots.vcxproj
+++ b/Trajectory_Hotspots/Test_Trajectory_Hotspots/Test_Trajectory_Hotspots.vcxproj
@@ -128,6 +128,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>..\Trajectory_Hotspots\$(Platform)\$(Configuration)\*.obj</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Trajectory_Hotspots/Trajectory_Hotspots/Trajectory_Hotspots.vcxproj
+++ b/Trajectory_Hotspots/Trajectory_Hotspots/Trajectory_Hotspots.vcxproj
@@ -118,6 +118,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
fix the "incremental ltcg not compatible with address sanitizer" warning by switching from /LTCG:incremental to /LTCG